### PR TITLE
use newer validation subdomain format in draft-ietf-acme-dns-account-label

### DIFF
--- a/va/va.go
+++ b/va/va.go
@@ -367,11 +367,7 @@ func (va VAImpl) validateDNS01(task *vaTask) *core.ValidationRecord {
 func (va VAImpl) validateDNSAccount01(task *vaTask) *core.ValidationRecord {
 	acctHash := sha256.Sum256([]byte(task.AccountURL))
 	acctLabel := strings.ToLower(base32.StdEncoding.EncodeToString(acctHash[0:10]))
-	scope := "host"
-	if task.Wildcard {
-		scope = "wildcard"
-	}
-	challengeSubdomain := fmt.Sprintf("_%s._acme-%s-challenge.%s", acctLabel, scope, task.Identifier.Value)
+	challengeSubdomain := fmt.Sprintf("_%s._acme-challenge.%s", acctLabel, task.Identifier.Value)
 
 	result := &core.ValidationRecord{
 		URL:         challengeSubdomain,


### PR DESCRIPTION
at 2024 November draft writers decide to drop concept in dns-account-01 challenge,  changed validation subdomain schema

this likely solve long staying CI fail from eggsampler/acme  (they applied this change much earlier than here, causing test to fail)